### PR TITLE
service-registry-eureka-server

### DIFF
--- a/micro-services-springboot-department-service/pom.xml
+++ b/micro-services-springboot-department-service/pom.xml
@@ -29,6 +29,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		 <spring-cloud.version>2023.0.5</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -71,9 +72,25 @@
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
 			<version>3.1.0</version>
-		</dependency>
+		</dependency>		
+	    <dependency>
+	      <groupId>org.springframework.cloud</groupId>
+	      <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+	    </dependency>			
 	</dependencies>
 
+	<dependencyManagement>
+	    <dependencies>
+	      <dependency>
+	        <groupId>org.springframework.cloud</groupId>
+	        <artifactId>spring-cloud-dependencies</artifactId>
+	        <version>2023.0.5</version>
+	        <type>pom</type>
+	        <scope>import</scope>
+	      </dependency>
+	    </dependencies>
+	  </dependencyManagement>
+	  
 	<build>
 		<plugins>
 			<plugin>

--- a/micro-services-springboot-department-service/src/main/java/com/example/departmentservice/MicroServicesSpringbootDepartmentServiceApplication.java
+++ b/micro-services-springboot-department-service/src/main/java/com/example/departmentservice/MicroServicesSpringbootDepartmentServiceApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
+//@EnableEurekaClient
 public class MicroServicesSpringbootDepartmentServiceApplication {
 
 

--- a/micro-services-springboot-department-service/src/main/resources/application.properties
+++ b/micro-services-springboot-department-service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=micro-services-springboot-department-service
+spring.application.name=department-service
 server.port = 8080
 #---------------------------DB congifs----------------------------------------
 spring.datasource.url=jdbc:mysql://localhost:3306/department_db
@@ -13,3 +13,6 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 
 #-------------------------------------------------------------------
+
+#Configuring Eureka Server URL
+eureka.instance.client.serverUrl.defaultZone=http://localhost:8761/eureka/


### PR DESCRIPTION
### **Service Registry and Discovery**
1. In the microservices projects, Service Registry and Discovery play an important role because we most likely run multiple instances of services and we need a mechanism to call other services without hardcoding their hostnames or port numbers.
2. In addition to that, in Cloud environments service instances may come up and go down anytime. So we need some automatic service registration and discovery mechanism.
3. Spring Cloud addresses this problem by providing Spring Cloud Netflix Eureka project to create Service Registry and Discovery.

We need to add _@EnableEurekaServer_ annotation to make our SpringBoot application a Eureka Server-based Service Registry.
It has in-built UI. - http://localhost:8761/

It also provides Spring Cloud Load balancer - Dynamic API calling.